### PR TITLE
Use separate NSPasteBoardItems for compability with Microsoft Word

### DIFF
--- a/Source/GPGServices.m
+++ b/Source/GPGServices.m
@@ -1051,10 +1051,19 @@
     
 	if(newString!=nil)
 	{
-		[pboard declareTypes:[NSArray arrayWithObjects:NSPasteboardTypeHTML, NSPasteboardTypeString, NSPasteboardTypeRTF, nil] owner:nil];
-		[pboard setString:[newString stringByReplacingOccurrencesOfString:@"\n" withString:@"<br>"] forType:NSPasteboardTypeHTML];
-		[pboard setString:newString forType:NSPasteboardTypeString];
-   		[pboard setString:newString forType:NSPasteboardTypeRTF];
+        [pboard clearContents];
+
+        NSPasteboardItem *stringItem = [[[NSPasteboardItem alloc] init] autorelease];
+        [stringItem setString:newString forType:NSPasteboardTypeString];
+
+        NSPasteboardItem *htmlItem = [[[NSPasteboardItem alloc] init] autorelease];
+        [htmlItem setString:[newString stringByReplacingOccurrencesOfString:@"\n" withString:@"<br>"] 
+                    forType:NSPasteboardTypeHTML];
+
+        NSPasteboardItem *rtfItem = [[[NSPasteboardItem alloc] init] autorelease];
+        [rtfItem setString:newString forType:NSPasteboardTypeRTF];
+
+        [pboard writeObjects:[NSArray arrayWithObjects:stringItem, htmlItem, rtfItem, nil]];
 	}
     
     [pool release];


### PR DESCRIPTION
Apple docs (url below) show how to write multiple items to the pasteboard
in 10.6 or later. This fixes GPGServices in Microsoft Word and works
as before in TextEdit, etc.

https://developer.apple.com/library/mac/#documentation/Cocoa/Reference/ApplicationKit/Classes/NSPasteboard_Class/Reference/Reference.html
