### PR TITLE
Update criteria for canEncrypt and canSign inline with GPGMail

### DIFF
--- a/Source/GPGServices.m
+++ b/Source/GPGServices.m
@@ -132,31 +132,24 @@
 #pragma mark -
 #pragma mark Validators
 
-// Shouldn't RecipientWindowController use canEncryptValidator somehow?
 + (KeyValidatorT)canEncryptValidator {
-    id block = ^(GPGKey* key) {
-        // A subkey can be expired, without the key being, thus making key useless 
-        // because it has no other subkey...
-        // We don't care about ownerTrust, validity
-        
-        for (GPGSubkey *aSubkey in [key subkeys]) {
-            if ([aSubkey canEncrypt] && 
-                ![aSubkey expired] && 
-                ![aSubkey revoked] &&
-                ![aSubkey invalid] &&
-                ![aSubkey disabled]) {
-                return YES;
-            }
-        }
+    KeyValidatorT block = ^(GPGKey* key) {
+        if ([key canAnyEncrypt] && key.status < GPGKeyStatus_Invalid)
+            return YES;
         return NO;
     };
     
     return [[block copy] autorelease];
 }
 
-// Warning : KeyChooserWindowController and RecipientWindowController assume canSignValidator = isActiveValidator
 + (KeyValidatorT)canSignValidator {
-    return [self isActiveValidator];
+    KeyValidatorT block = ^(GPGKey* key) {
+        if ([key canAnySign] && key.status < GPGKeyStatus_Invalid)
+            return YES;
+        return NO;
+    };
+    
+    return [[block copy] autorelease];
 }
 
 + (KeyValidatorT)isActiveValidator {

--- a/Source/KeyChooserDataSource.m
+++ b/Source/KeyChooserDataSource.m
@@ -82,10 +82,12 @@
                         change:(NSDictionary *)change
                        context:(void *)context {    
     
-    if([keyPath isEqualToString:@"keyValidator"])
-        self.availableKeys = [self getPrivateKeys];
-    
-    [self updateDescriptions];
+    if([keyPath isEqualToString:@"keyValidator"]) {
+        [self update];
+    }
+    else {
+        [self updateDescriptions];
+    }
 }
 
 - (void)updateDescriptions {
@@ -124,11 +126,10 @@
         self.selectedKey = nil;
     self.availableKeys = nowAvailableKeys;
 
-    GPGKey *nowDefaultKey = [self getDefaultKey];
-    if (!nowDefaultKey)
-        self.selectedKey = nil;
-    else if ([nowAvailableKeys containsObject:nowDefaultKey])
-        self.selectedKey = nowDefaultKey;
+    GPGKey *nowSelected = self.selectedKey;
+    if (!nowSelected)
+        nowSelected = [self getDefaultKey];
+    self.selectedIndex = [self.availableKeys indexOfObject:nowSelected];
 
     [self updateDescriptions];
 }

--- a/Source/KeyChooserWindowController.m
+++ b/Source/KeyChooserWindowController.m
@@ -32,7 +32,7 @@
 - (void)windowDidLoad {
 	[super windowDidLoad];
 	
-    dataSource.keyValidator = [GPGServices canSignValidator]; 
+    dataSource.keyValidator = [GPGServices isActiveValidator]; 
     [dataSource update];
 }
 


### PR DESCRIPTION
http://support.gpgtools.org/discussions/everything/221-problems-with-installing-gpgtools
- new "canEncrypt": (canAnyEncrypt && status < invalid)
- new "canSign": (canAnySign && status < invalid)
- fix: [KeyChooserDataSource update] should manage selectedIndex, not
  selectedKey, in order to handle any possible content changes
  from an altered keyValidator. "keyValidator" observer should
  call [KeyChooserDataSource update] rather than managing
  self.availableKeys itself.
- KeyChooserWindowController uses [GPGServices isActiveValidator],
  which [GPGServices canSignValidator] formerly aliased
