### PR TITLE
Improve signed file/signature file heuristic

### DIFF
--- a/Source/GPGServices.m
+++ b/Source/GPGServices.m
@@ -1091,12 +1091,15 @@ static const float kBytesInMB = 1.e6; // Apple now uses this vs 2^20
             return;
         
         //Do the file stuff here to be able to check if file is already in verification
-        NSString* signatureFile = serviceFile;
-        NSString* signedFile = [FileVerificationController searchFileForSignatureFile:signatureFile];
-        if(signedFile == nil) {
-            NSString* tmp = [FileVerificationController searchSignatureFileForFile:signatureFile];
-            signedFile = signatureFile;
-            signatureFile = tmp;
+        NSString* signedFile = serviceFile;
+        NSString* signatureFile = [FileVerificationController searchSignatureFileForFile:signedFile];
+        if (signatureFile == nil) {
+            signatureFile = serviceFile;
+            signedFile = [FileVerificationController searchFileForSignatureFile:signatureFile];
+        }
+        if (signedFile == nil) {
+            signedFile = serviceFile;
+            signatureFile = nil;
         }
         
         if(signatureFile != nil) {


### PR DESCRIPTION
Thought I would get this one in which I just found but you 
were fast on my last one.

Anyway, interesting (bad) behavior in the old GPGServices when 
verifying a file with a detached signature.
- previously, did search for smaller filename before searching
  for longer filename. I.e., searched by removing extension
  first.
- now searching for an added extension first is more reliable
  in case a signed-encrypted file has been decrypted in the
  directory.

E.g., old behavior:
If a directory contains: out, out.gpg, and out.gpg.sig, and
the user was verifying out.gpg, the old heuristic would see
out as the signed file and out.gpg as the signature file.

New behavior:
The new heuristic will match the longer name first, so it would
correctly process out.gpg as the data and out.gpg.sig as the
signature.
