### PR TITLE
Only zip dirs

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -40,7 +40,7 @@
 "Decryption finished (partially)" = "Decryption finished (partially)";
 
 /* arg1:successCount arg2:totalCount */
-"Encrypted %1$u of %2$u files" = "Encrypted %1$u of %2$u files";
+"Encrypted %1$u of %2$u selections" = "Encrypted %1$u of %2$u selections";
 
 /* arg:filename */
 "Encrypted %@" = "Encrypted %@";

--- a/Source/GPGServices.m
+++ b/Source/GPGServices.m
@@ -1033,7 +1033,7 @@ static NSUInteger const suffixLen = 5;
                                                     successCount:outCount 
                                                    singleFileFmt:NSLocalizedString(@"Encrypted %@", @"arg:filename") 
                                                    singleFailFmt:NSLocalizedString(@"Failed encrypting %@", @"arg:filename")
-                                                  pluralFilesFmt:NSLocalizedString(@"Encrypted %1$u of %2$u files", @"arg1:successCount arg2:totalCount")]];
+                                                  pluralFilesFmt:NSLocalizedString(@"Encrypted %1$u of %2$u selections", @"arg1:successCount arg2:totalCount")]];
     if ([errorMsgs count]) {
         [message appendString:@"\n\n"];
         [message appendString:[errorMsgs componentsJoinedByString:@"\n"]];


### PR DESCRIPTION
Hi, guys.

Here's a pull request I forgot to send months ago. It satisfies issue http://gpgtools.lighthouseapp.com/projects/67607-gpgservices/tickets/43 —Alex's proposal "to create zip archives for directories only."

Also:

option "UseASCIIOutput" is retired; instead gpg.conf "armor" will be used to specify when to create .asc files instead of .gpg files when encrypting. This restores the behavior that was lost in a release this year.
"emit-version" in gpg.conf is respected for .asc output (i.e., when "armor" is active)
"comments" in gpg.conf are included in .asc output (i.e., when "armor" is active)
